### PR TITLE
Fix timer response field typo

### DIFF
--- a/src/main/java/studyMate/dto/pomodoro/TimerResDto.java
+++ b/src/main/java/studyMate/dto/pomodoro/TimerResDto.java
@@ -13,6 +13,6 @@ public class TimerResDto {
     private String timerType;   // STUDY 또는 BREAK
     private String userNickname;
     private int studyTimes;   //  공부한 시간
-    private int breakTiems;   // 휴식한 시간
+    private int breakTimes;   // 휴식한 시간
     private int cycleCount;     // 현재 사이클 수
 } 

--- a/src/main/java/studyMate/service/TimerService.java
+++ b/src/main/java/studyMate/service/TimerService.java
@@ -117,7 +117,7 @@ public class TimerService {
                 .timerType(status.getTimerType())
                 .userNickname(user.getNickname())
                 .studyTimes(status.getStudyMinutes())
-                .breakTiems(status.getBreakMinutes())
+                .breakTimes(status.getBreakMinutes())
                 .cycleCount(status.getCycleCount())
                 .build();
     }


### PR DESCRIPTION
## Summary
- correct typo `breakTiems` -> `breakTimes`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6878d137ec0083238b8e04f100658858