### PR TITLE
Fix OpenAiProperties class name

### DIFF
--- a/src/main/java/studyMate/config/OpenAiProperties.java
+++ b/src/main/java/studyMate/config/OpenAiProperties.java
@@ -8,6 +8,6 @@ import org.springframework.context.annotation.Configuration;
 @Getter @Setter
 @Configuration
 @ConfigurationProperties(prefix = "openai")
-public class OpenAiProrperties {
+public class OpenAiProperties {
     private String apikey;
 }

--- a/src/main/java/studyMate/config/WebClientConfig.java
+++ b/src/main/java/studyMate/config/WebClientConfig.java
@@ -7,10 +7,12 @@ import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.http.HttpHeaders;
 
+import studyMate.config.OpenAiProperties;
+
 @Configuration
 @RequiredArgsConstructor
 public class WebClientConfig {
-    private final OpenAiProrperties openAiProrperties;
+    private final OpenAiProperties openAiProrperties;
 
     @Bean
     public WebClient openAiWebClient() {

--- a/src/main/java/studyMate/service/AiFeedbackService.java
+++ b/src/main/java/studyMate/service/AiFeedbackService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import studyMate.config.OpenAiProrperties;
+import studyMate.config.OpenAiProperties;
 import studyMate.dto.ai.*;
 import studyMate.entity.Timer;
 import studyMate.repository.TimerRepository;
@@ -17,7 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AiFeedbackService {
     private final WebClient openAiWebClient;
-    private final OpenAiProrperties openAiProrperties;
+    private final OpenAiProperties openAiProrperties;
     private final TimerRepository timerRepository;
 
     public AiFeedbackResponse getFeedback(AiFeedbackRequest request) {


### PR DESCRIPTION
## Summary
- rename `OpenAiProrperties` to `OpenAiProperties`
- update `WebClientConfig` and `AiFeedbackService` references
- keep `@ConfigurationProperties` scanning

## Testing
- `gradle test` *(fails: Plugin not found because repository access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6878d47dd46c8323b3cb66bb8387cb20